### PR TITLE
Improve AIRS landing page structure

### DIFF
--- a/src/components/AirsCard/index.jsx
+++ b/src/components/AirsCard/index.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import styles from "./styles.module.css";
+
+export default function AirsCard({
+  title,
+  children,
+  link,
+  linkLabel,
+  colorMode,
+  className,
+  style,
+}) {
+  const isDark = colorMode === "dark";
+  const bg = isDark ? "#22252a" : "#fff";
+  const border = isDark ? "1px solid #333a48" : "1px solid #e0e7ef";
+  const shadow = isDark
+    ? "0 2px 12px 0 rgba(0,0,0,0.24)"
+    : "0 2px 12px 0 rgba(0,0,0,0.04)";
+  const text = isDark ? "#fff" : "#222";
+  const desc = isDark ? "#c9ccd1" : "#444";
+  const linkColor = isDark ? "#66bfff" : "#005fa3";
+  const [hover, setHover] = React.useState(false);
+
+  return (
+    <div
+      className={`${styles.card} ${className || ""}`}
+      style={{
+        background: bg,
+        border,
+        boxShadow: hover
+          ? isDark
+            ? "0 4px 24px 0 rgba(255,97,51,0.10)"
+            : "0 4px 24px 0 rgba(255,97,51,0.06)"
+          : shadow,
+        color: text,
+        ...style,
+      }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <h3 className={styles.title} style={{ color: text }}>
+        {title}
+      </h3>
+      <div style={{ marginBottom: 12, color: desc }}>{children}</div>
+      {link && (
+        <a
+          href={link}
+          target={link.startsWith("/prisma-airs") ? "_self" : "_blank"}
+          rel="noopener noreferrer"
+          className={styles.link}
+          style={{ color: linkColor }}
+        >
+          {linkLabel || "Learn more"} ↗
+        </a>
+      )}
+    </div>
+  );
+}

--- a/src/components/AirsCard/styles.module.css
+++ b/src/components/AirsCard/styles.module.css
@@ -1,0 +1,24 @@
+.card {
+  border-radius: 16px;
+  padding: 28px;
+  margin-bottom: 24px;
+  flex: 1;
+  min-width: 260px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  transition: box-shadow 0.2s, border 0.2s, background 0.2s;
+  cursor: default;
+}
+
+.title {
+  margin-top: 0;
+  font-weight: 700;
+}
+
+.link {
+  font-weight: 500;
+  margin-top: auto;
+  text-decoration: none;
+  transition: color 0.2s;
+}

--- a/src/pages/airs/index.js
+++ b/src/pages/airs/index.js
@@ -4,67 +4,7 @@ import styles from "./styles.module.css";
 import { useColorMode } from "@docusaurus/theme-common";
 import CodeBlock from "@theme/CodeBlock";
 import UseCasesTabs from "../../components/UseCasesTabs";
-
-const Card = ({ title, children, link, linkLabel, colorMode }) => {
-  const isDark = colorMode === "dark";
-  const bg = isDark ? "#22252a" : "#fff";
-  const border = isDark ? "1px solid #333a48" : "1px solid #e0e7ef";
-  const shadow = isDark
-    ? "0 2px 12px 0 rgba(0,0,0,0.24)"
-    : "0 2px 12px 0 rgba(0,0,0,0.04)";
-  const text = isDark ? "#fff" : "#222";
-  const desc = isDark ? "#c9ccd1" : "#444";
-  const linkColor = isDark ? "#66bfff" : "#005fa3";
-
-  // Hover effect handlers
-  const [hover, setHover] = React.useState(false);
-
-  return (
-    <div
-      style={{
-        background: bg,
-        border,
-        borderRadius: 16,
-        boxShadow: hover
-          ? isDark
-            ? "0 4px 24px 0 rgba(255,97,51,0.10)"
-            : "0 4px 24px 0 rgba(255,97,51,0.06)"
-          : shadow,
-        padding: 28,
-        marginBottom: 24,
-        flex: 1,
-        minWidth: 260,
-        color: text,
-        transition: "box-shadow 0.2s, border 0.2s, background 0.2s",
-        cursor: "default",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "flex-start",
-      }}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-    >
-      <h3 style={{ marginTop: 0, color: text }}>{title}</h3>
-      <div style={{ marginBottom: 12, color: desc }}>{children}</div>
-      {link && (
-        <a
-          href={link}
-          target={link.startsWith("/prisma-airs") ? "_self" : "_blank"}
-          rel="noopener noreferrer"
-          style={{
-            color: linkColor,
-            fontWeight: 500,
-            marginTop: "auto",
-            textDecoration: "none",
-            transition: "color 0.2s",
-          }}
-        >
-          {linkLabel || "Learn more"} ↗
-        </a>
-      )}
-    </div>
-  );
-};
+import AirsCard from "../../components/AirsCard";
 
 export default function AIRSApiIntercept() {
   return (
@@ -89,16 +29,7 @@ function MainContent() {
       }}
     >
       {/* Hero Section */}
-      <section
-        className={styles.heroSection}
-        style={{
-          padding: "36px 0 24px 0",
-          background: "#171717", // Brand dark
-          borderBottom: "1px solid #222",
-          color: "#fff",
-          transition: "background 0.3s",
-        }}
-      >
+      <section className={styles.heroSection}>
         <div className={styles.heroAnimatedBg}>
           <div className={`${styles.heroBlob} ${styles.heroBlob1}`} />
           <div className={`${styles.heroBlob} ${styles.heroBlob2}`} />
@@ -117,39 +48,12 @@ function MainContent() {
             flexDirection: "column",
             alignItems: "flex-start",
             justifyContent: "center",
-            // (removed custom horizontal padding, rely on .container class for horizontal padding)
           }}
         >
           {/* Optional: Add logo/icon for extra polish */}
           {/* <ApiLogo style={{ height: 56, marginBottom: 24 }} /> */}
-          <div
-            style={{
-              background: "rgba(20, 20, 20, 0.68)",
-              borderRadius: 18,
-              padding:
-                "clamp(24px, 6vw, 40px) clamp(12px, 4vw, 40px) 16px clamp(12px, 4vw, 40px)",
-              boxShadow: "0 4px 32px 0 rgba(0,0,0,0.22)",
-              zIndex: 2,
-              position: "relative",
-              backdropFilter: "blur(2px)",
-              WebkitBackdropFilter: "blur(2px)",
-              maxWidth: "min(100%, 1100px)",
-              width: "100%",
-              marginBottom: 8,
-              textAlign: "left",
-            }}
-          >
-            <h1
-              style={{
-                margin: 0,
-                fontSize: 40,
-                fontWeight: 700,
-                letterSpacing: -1,
-                lineHeight: 1.1,
-                color: "#fff",
-                textAlign: "left",
-              }}
-            >
+          <div className={styles.heroGlass}>
+            <h1 className={styles.heroHeading}>
               Secure your{" "}
               <span
                 style={{
@@ -181,17 +85,7 @@ function MainContent() {
               .
             </h1>
             <div style={{ marginBottom: 28 }}>
-              <p
-                style={{
-                  margin: "28px 0 0 0",
-                  fontSize: 22,
-                  color: "#fff",
-                  fontWeight: 400,
-                  lineHeight: 1.4,
-                  textAlign: "left",
-                  maxWidth: 820,
-                }}
-              >
+              <p className={styles.heroSubheading}>
                 Prisma AIRS API Intercept is Palo Alto Networks’ API for
                 securing AI applications and agents. Instantly protect your
                 models from prompt injection, data leaks, and unsafe outputs—so
@@ -300,7 +194,7 @@ print(res)
       </div>
       <div className={styles.responsiveSection} style={{ marginTop: 24 }}>
         <section className={styles.gridSection}>
-          <Card
+          <AirsCard
             title={
               <span
                 style={{
@@ -346,8 +240,8 @@ print(res)
             >
               View Python SDK Docs
             </a>
-          </Card>
-          <Card
+          </AirsCard>
+          <AirsCard
             title="API Reference"
             link="/prisma-airs/api/airuntimesecurity/prisma-airs-api/"
             linkLabel="Full API Reference"
@@ -357,8 +251,8 @@ print(res)
               Full API documentation with endpoint details, request/response
               formats, authentication, error codes, and code samples.
             </div>
-          </Card>
-          <Card
+          </AirsCard>
+          <AirsCard
             title="Getting Started"
             link="https://docs.paloaltonetworks.com/ai-runtime-security/activation-and-onboarding/ai-runtime-security-api-intercept-overview"
             linkLabel="Read the Guide"
@@ -368,7 +262,7 @@ print(res)
               Guided setup for developers: activate your profile, configure
               security, generate API keys, and integrate with your app.
             </div>
-          </Card>
+          </AirsCard>
         </section>
       </div>
     </main>

--- a/src/pages/airs/styles.module.css
+++ b/src/pages/airs/styles.module.css
@@ -125,7 +125,21 @@
   min-height: 440px;
   overflow: hidden;
   position: relative;
-  padding: 3.5rem 0;
+  padding: 36px 0 24px 0;
+  transition: background 0.3s;
+  border-bottom: 1px solid;
+  color: #fff;
+  background: linear-gradient(135deg, #171717 0%, #1f2937 100%);
+}
+
+html[data-theme="light"] .heroSection {
+  color: #171717;
+  background: linear-gradient(135deg, #f5f7fa 0%, #ffffff 100%);
+  border-bottom-color: #e0e7ef;
+}
+
+html[data-theme="dark"] .heroSection {
+  border-bottom-color: #222;
 }
 
 @media (max-width: 700px) {
@@ -137,6 +151,27 @@
 .container {
   position: relative;
   z-index: 1;
+}
+
+.heroGlass {
+  background: rgba(20, 20, 20, 0.68);
+  border-radius: 18px;
+  padding: clamp(24px, 6vw, 40px) clamp(12px, 4vw, 40px) 16px
+    clamp(12px, 4vw, 40px);
+  box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 0.22);
+  z-index: 2;
+  position: relative;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  max-width: min(100%, 1100px);
+  width: 100%;
+  margin-bottom: 8px;
+  text-align: left;
+}
+
+html[data-theme="light"] .heroGlass {
+  background: rgba(255, 255, 255, 0.9);
+  color: #171717;
 }
 
 .heroAnimatedBg {
@@ -192,6 +227,26 @@
   opacity: 0.45;
   filter: blur(32px);
   animation-timing-function: ease-in-out;
+}
+
+.heroHeading {
+  margin: 0;
+  font-size: 40px;
+  font-weight: 700;
+  letter-spacing: -1px;
+  line-height: 1.1;
+  text-align: left;
+  color: inherit;
+}
+
+.heroSubheading {
+  margin: 28px 0 0 0;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1.4;
+  text-align: left;
+  max-width: 820px;
+  color: inherit;
 }
 
 .heroBlob1 {


### PR DESCRIPTION
## Summary
- refine hero section styles and move them to CSS
- lighten hero for light mode while keeping dark mode gradient
- use new heroHeading and heroSubheading classes

## Testing
- `npx prettier --check src/pages/airs/index.js src/pages/airs/styles.module.css src/components/AirsCard/index.jsx src/components/AirsCard/styles.module.css`


------
https://chatgpt.com/codex/tasks/task_e_6852d19f6f6083239a3a8bb1fc267846