### PR TITLE
Fix Tailwind import to avoid style override

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -11,15 +11,8 @@
  */
 /* You can override the default Infima variables here. */
 
-@use "tailwindcss";
-
-// revert default list-style overridden by tailwindcss
-@layer base {
-  ul,
-  ol {
-    list-style: revert;
-  }
-}
+/* Import only Tailwind utilities to avoid style overrides */
+@use "tailwindcss/utilities";
 
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
 


### PR DESCRIPTION
## Summary
- limit Tailwind import to utilities only to stop overriding Docusaurus styles

## Testing
- `yarn lint` *(fails: Couldn't find a script named "lint")*
- `npx prettier -w src/css/custom.scss`

------
https://chatgpt.com/codex/tasks/task_e_685313cd7bcc8323afc4bb3201bbfd8d