### PR TITLE
Add raw markdown display

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -22,7 +22,7 @@ if (process.env.CI_MERGE_REQUEST_IID) {
 const config = {
   future: {
     experimental_faster: (process.env.DOCUSAURUS_FASTER ?? "true") === "true",
-    v4: true
+    v4: true,
   },
   title: "Develop with Palo Alto Networks",
   tagline:
@@ -1171,6 +1171,7 @@ const config = {
       },
     ],
     tailwindPlugin,
+    require.resolve("./plugins/markdown-route/index.cjs"),
   ],
   stylesheets: [
     {

--- a/plugins/markdown-route/index.cjs
+++ b/plugins/markdown-route/index.cjs
@@ -3,8 +3,9 @@ function markdownRoutePlugin() {
     name: "markdown-route-plugin",
     async contentLoaded({ actions }) {
       actions.addRoute({
-        path: "/:route+\\.md",
+        path: "/:route+.md",
         component: "@site/src/components/MarkdownPage",
+        exact: true,
       });
     },
   };

--- a/plugins/markdown-route/index.cjs
+++ b/plugins/markdown-route/index.cjs
@@ -3,7 +3,8 @@ function markdownRoutePlugin() {
     name: "markdown-route-plugin",
     async contentLoaded({ actions }) {
       actions.addRoute({
-        path: "/:route+.md",
+        path: "/__rawmd",
+        matchPath: "/:route+.md",
         component: "@site/src/components/MarkdownPage",
         exact: true,
       });

--- a/plugins/markdown-route/index.cjs
+++ b/plugins/markdown-route/index.cjs
@@ -1,0 +1,12 @@
+function markdownRoutePlugin() {
+  return {
+    name: "markdown-route-plugin",
+    async contentLoaded({ actions }) {
+      actions.addRoute({
+        path: "/:route+\\.md",
+        component: "@site/src/components/MarkdownPage",
+      });
+    },
+  };
+}
+module.exports = markdownRoutePlugin;

--- a/plugins/markdown-route/index.cjs
+++ b/plugins/markdown-route/index.cjs
@@ -3,10 +3,9 @@ function markdownRoutePlugin() {
     name: "markdown-route-plugin",
     async contentLoaded({ actions }) {
       actions.addRoute({
-        path: "/__rawmd",
+        path: "/__md",
         matchPath: "/:route+.md",
         component: "@site/src/components/MarkdownPage",
-        exact: true,
       });
     },
   };

--- a/src/components/MarkdownPage.tsx
+++ b/src/components/MarkdownPage.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+import { useLocation } from "@docusaurus/router";
+import TurndownService from "turndown";
+
+export default function MarkdownPage() {
+  const location = useLocation();
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchAndConvert() {
+      const htmlPath = location.pathname.replace(/\.md$/, "/");
+      try {
+        const res = await fetch(htmlPath);
+        if (!res.ok) {
+          throw new Error(`Failed to fetch source page: ${res.status}`);
+        }
+        const html = await res.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, "text/html");
+        const content =
+          doc.querySelector(".openapi-left-panel__container") ||
+          doc.querySelector(".theme-doc-markdown");
+        if (!content) {
+          throw new Error("Unable to locate markdown source");
+        }
+        const turndownService = new TurndownService();
+        turndownService.addRule("details-rule", {
+          filter: "details",
+          replacement: function (content, node) {
+            const summary = node.querySelector("summary");
+            const summaryText = summary ? summary.textContent?.trim() : "";
+            const detailsContent = content.substring(
+              content.indexOf("</summary>") + 1
+            );
+            let md = `\n${summaryText}\n`;
+            const indented = detailsContent
+              .split("\n")
+              .map((line) => {
+                if (line.trim() === "") return line;
+                return `    ${line}`;
+              })
+              .join("\n");
+            md += indented;
+            return md + "\n";
+          },
+        });
+        setMarkdown(turndownService.turndown(content));
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    }
+    fetchAndConvert();
+  }, [location.pathname]);
+
+  if (error) {
+    return <pre>{error}</pre>;
+  }
+  if (markdown === null) {
+    return <p>Loading...</p>;
+  }
+  return <pre>{markdown}</pre>;
+}

--- a/src/components/MarkdownPage.tsx
+++ b/src/components/MarkdownPage.tsx
@@ -9,7 +9,7 @@ export default function MarkdownPage() {
 
   useEffect(() => {
     async function fetchAndConvert() {
-      const htmlPath = location.pathname.replace(/\.md$/, "/");
+      const htmlPath = location.pathname.replace(/\.md$/, "/index.html");
       try {
         const res = await fetch(htmlPath);
         if (!res.ok) {
@@ -53,11 +53,22 @@ export default function MarkdownPage() {
     fetchAndConvert();
   }, [location.pathname]);
 
+  const preStyle: React.CSSProperties = {
+    all: "unset",
+    whiteSpace: "pre-wrap",
+    fontFamily: "monospace",
+    display: "block",
+    padding: 0,
+    margin: 0,
+    background: "transparent",
+    color: "inherit",
+  };
+
   if (error) {
-    return <pre>{error}</pre>;
+    return <pre style={preStyle}>{error}</pre>;
   }
   if (markdown === null) {
     return <p>Loading...</p>;
   }
-  return <pre>{markdown}</pre>;
+  return <pre style={preStyle}>{markdown}</pre>;
 }


### PR DESCRIPTION
## Summary
- allow `.md` route to display markdown
- add plugin to register catch-all route
- implement markdown page component

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn format` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688133d7f8cc8323af71ef9c5c9a4ba6